### PR TITLE
Add the possibility to reorder matched candidates

### DIFF
--- a/examples/i3_workspaces.ml
+++ b/examples/i3_workspaces.ml
@@ -7,12 +7,12 @@ let get_workspace prompt =
 
 let () =
   try
-    match Sys.argv.(1) with
-    | "rename" ->
-      let ws = get_workspace "rename to:" in
+    match Array.to_list Sys.argv |> List.tl with
+    | "rename" :: _ ->
+      let ws = get_workspace "Rename to:" in
       Unix.execvp "i3-msg" [| "i3-msg"; "-q"; "rename"; "workspace"; "to"; ws |]
-    | "move" ->
-      let ws = get_workspace "move to:" in
+    | "move" :: _ ->
+      let ws = get_workspace "Move to:" in
       Unix.execvp "i3-msg"
         [| "i3-msg"; "-q"; "move"; "window"; "to"; "workspace"; ws |]
     | _ ->

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -56,6 +56,7 @@ end
 let run prompt stdin topbar focus_foreground focus_background normal_foreground
       normal_background match_foreground window_background lines = 
   let () = Matching.(set_match_query_fun @@ subset ~case:false) in
+  let () = Candidate.(set_reorder_matched_fun prefixes_first) in
   let colors = { X.Colors.focus_foreground; focus_background;
                  normal_foreground; normal_background; match_foreground; window_background } in
   let program = 

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -53,7 +53,7 @@ module Parameter = struct
       Arg.(value & flag & info ["s"; "stdin"] ~doc)
 end
 
-let run prompt stdin topbar focus_foreground focus_background normal_foreground
+let run prompt stdin botbar focus_foreground focus_background normal_foreground
       normal_background match_foreground window_background lines = 
   let () = Matching.(set_match_query_fun @@ subset ~case:false) in
   let () = Candidate.(set_reorder_matched_fun prefixes_first) in
@@ -71,7 +71,7 @@ let run prompt stdin topbar focus_foreground focus_background normal_foreground
     | 0 -> State.SingleLine
     | n -> State.MultiLine n
   in
-  match Dmlenu.run ~prompt ~layout ~topbar ~colors program with
+  match Dmlenu.run ~prompt ~layout ~topbar:(not botbar) ~colors program with
   | None -> ()
   | Some s -> print_endline s
 

--- a/lib/candidate.ml
+++ b/lib/candidate.ml
@@ -15,3 +15,15 @@ let make ?real ?(doc = "") ?matching_function ?completion display : t = {
   matching_function = 
     Option.default (Matching.match_query ~candidate: display) matching_function;
 }
+
+(* ************************************************************************** *)
+
+let prefixes_first =
+  List.partition (function
+    | (_, [(true, _, _); (false, _, _)]) -> true
+    |  _                                 -> false)
+  %> uncurry (@)
+
+let reorder_matched_fun = ref identity
+let reorder_matched l = !reorder_matched_fun l
+let set_reorder_matched_fun f = reorder_matched_fun := f

--- a/lib/candidate.mli
+++ b/lib/candidate.mli
@@ -29,3 +29,19 @@ val make : ?real:string -> ?doc:string -> ?matching_function:Matching.t ->
     - doc: empty
     - matching_function: Matching.match_query ~candidate
 *)
+
+(** {3 Reordering functions} *)
+
+(** After matching on candidates, a reordering function is called that can
+    change their order. *)
+
+val reorder_matched : (t * Matching.result) list -> (t * Matching.result) list
+(** The reordering function (by default, the identity). *)
+
+val set_reorder_matched_fun : ((t * Matching.result) list -> (t * Matching.result) list) -> unit
+(** Set the reordering function. *)
+
+(** {2 Predefined reordering functions} *)
+
+(** Reorder the candidates to put prefix matchings first. *)
+val prefixes_first : (t * Matching.result) list -> (t * Matching.result) list

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -45,7 +45,7 @@ let update_sources ?(input="") split sources =
     r := !r @ List.filter_map test candidates; (* !r is empty most of the times *)
     Source.ST (state', s))
   in
-  sources, Pagination.from_list split !r
+  sources, Pagination.from_list split (Candidate.reorder_matched !r)
 
 let update_layout state candidates =
   match state.layout with


### PR DESCRIPTION
The behavior of the [main] binary is also changed, matching prefixes
first, to match dmenu's behavior.

I'm not even sure if the code is in the right place nor if its the right API.
I followed the API style of Matching functions, but had to put the reordering functions in the Candidate module.