### PR TITLE
Better API for candidates reordering functions & documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-A library to easily create dmenu like applications.
+A library to easily create dmenu-like applications.
 
 Dependencies
 ------------
 
 - Oasis
 - Batteries
-- Yojson (optionnal)
-- Cmdliner (optionnal, needed only to build the examples)
+- Yojson (optional)
+- Cmdliner (optional, needed only to build the examples)
 
 Building and installing
 -----------------------
@@ -16,8 +16,16 @@ Building and installing
     $ make
     $ make install
 
+Examples
+--------
+
+In the `examples/` directory. They can be built using:
+
+    $ ./configure --enable-examples # optionally: --enable-extra
+    $ make
+
 Documentation
 -------------
 
-Once `oasis setup` has run, just call `make doc`.  
+Once `oasis setup` has run, just call `make doc`.
 Or just go to : http://the-lambda-church.github.io/dmlenu/

--- a/_oasis
+++ b/_oasis
@@ -40,7 +40,7 @@ Library "dmlenu"
     CCLib:                -lX11 -lXinerama
   else
     CCLib:                -lX11
-  Modules:              Candidate, Matching, Pagination, Source, Engine, State, Dmlenu, X
+  Modules:              Candidate, Matching, Ordering, Pagination, Source, Engine, State, Dmlenu, X
   CSources:             draw_funs.h, draw_funs.c, draw_stubs.c
   BuildDepends:         batteries,lwt
   XMetaDescription:     An OCaml library to easily create dmenu-like examples

--- a/_oasis
+++ b/_oasis
@@ -54,7 +54,7 @@ Library "dmlenu-extra"
   Modules:              Extra_sources
   BuildDepends:         dmlenu, yojson
   XMetaDescription:     Extra sources for the dmlenu library.
- 
+
 Executable "dmlenu"
   Build$:               flag(examples) || flag(all)
   Install:              true
@@ -86,7 +86,7 @@ Executable "dmlenu_mpcgrid"
   MainIs:               mpc2D.ml
   BuildDepends:         dmlenu,dmlenu.extra
   CompiledObject:       best
- 
+
 Document "dmlenu-api"
   Title:                API reference for Dmlenu
   Build:                true
@@ -95,7 +95,7 @@ Document "dmlenu-api"
   Type:                 ocamlbuild (0.3)
   XOCamlbuildPath:      ./
   XOCamlbuildLibraries: dmlenu, dmlenu.extra
- 
+
 SourceRepository head
   Type:         git
   Location:     https://github.com/the-lambda-church/dmlenu.git

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -56,7 +56,7 @@ end
 let run prompt stdin botbar focus_foreground focus_background normal_foreground
       normal_background match_foreground window_background lines =
   let () = Matching.(set_match_query_fun @@ subset ~case:false) in
-  let () = Candidate.(set_reorder_matched_fun prefixes_first) in
+  let () = Ordering.(set_reorder_matched_fun prefixes_first) in
   let colors = { X.Colors.focus_foreground; focus_background;
                  normal_foreground; normal_background; match_foreground; window_background } in
   let program =

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -2,9 +2,9 @@ open Batteries
 open Cmdliner
 open Candidate
 module Parameter = struct
-    let normal_background_default = 
+    let normal_background_default =
       try Sys.getenv "DMENU_NORMAL_BACKGROUND" with _ -> "#222222"
-    let normal_foreground_default = 
+    let normal_foreground_default =
       try Sys.getenv "DMENU_NORMAL_FOREGROUND" with _ -> "#bbbbbb"
     let focus_background_default = try Sys.getenv "DMENU_FOCUS_BACKGROUND" with _ -> "#005577"
     let focus_foreground_default = try Sys.getenv "DMENU_FOCUS_FOREGROUND" with _ -> "#eeeeee"
@@ -16,56 +16,56 @@ module Parameter = struct
       let doc = "Prompt to be displayed on the left of the input field" in
       Arg.(value & opt string "" & info ["p"; "prompt"] ~docv:"PROMPT" ~doc)
 
-    let normal_background = 
+    let normal_background =
       let doc = "Normal background (for non focused elements)" in
       Arg.(value & opt string normal_background_default & info ["nb"] ~docv: "NB" ~doc)
 
-    let focus_background = 
+    let focus_background =
       let doc = "Focus background color (for focused elements)" in
       Arg.(value & opt string focus_background_default & info ["fb"] ~docv: "fB" ~doc)
 
-    let normal_foreground = 
+    let normal_foreground =
       let doc = "Normal foreground color (for non focused elements)" in
       Arg.(value & opt string normal_foreground_default & info ["nf"] ~docv: "NF" ~doc)
 
-    let focus_foreground = 
+    let focus_foreground =
       let doc = "Focus foreground color (for focused elements)" in
       Arg.(value & opt string focus_foreground_default & info ["ff"] ~docv: "ff" ~doc)
 
-    let match_foreground = 
+    let match_foreground =
       let doc = "Color to display matches inside candidates" in
       Arg.(value & opt string match_foreground_default & info ["ff"] ~docv: "mf" ~doc)
 
-    let window_background = 
+    let window_background =
       let doc = "Color of the window background" in
       Arg.(value & opt string window_background & info ["wb"] ~docv: "wb" ~doc)
 
-    let lines = 
+    let lines =
       let doc = "If set, display the candidates in lines" in
       Arg.(value & opt int 0 & info ["l"; "lines"] ~docv: "LINES" ~doc)
 
-    let bottom = 
+    let bottom =
       let doc = "If set, display the menu at the bottom of the screen" in
       Arg.(value & flag & info ["b"; "bottom"] ~doc)
 
-    let stdin = 
+    let stdin =
       let doc = "If set, read the candidates off stdin" in
       Arg.(value & flag & info ["s"; "stdin"] ~doc)
 end
 
 let run prompt stdin botbar focus_foreground focus_background normal_foreground
-      normal_background match_foreground window_background lines = 
+      normal_background match_foreground window_background lines =
   let () = Matching.(set_match_query_fun @@ subset ~case:false) in
   let () = Candidate.(set_reorder_matched_fun prefixes_first) in
   let colors = { X.Colors.focus_foreground; focus_background;
                  normal_foreground; normal_background; match_foreground; window_background } in
-  let program = 
+  let program =
     if stdin then Engine.singleton (Source.stdin ())
     else {
       Engine.sources = [ Source.binaries ];
       transition = fun o -> Extra_sources.stm_from_file o.display
     }
-  in    
+  in
   let layout =
     match lines with
     | 0 -> State.SingleLine
@@ -75,7 +75,7 @@ let run prompt stdin botbar focus_foreground focus_background normal_foreground
   | None -> ()
   | Some s -> print_endline s
 
-let info = 
+let info =
   let doc = "print a menu with customizable completion" in
   Term.info "dmlenu" ~version:"0.0" ~doc ~man:[]
 

--- a/lib/candidate.ml
+++ b/lib/candidate.ml
@@ -15,15 +15,3 @@ let make ?real ?(doc = "") ?matching_function ?completion display : t = {
   matching_function =
     Option.default (Matching.match_query ~candidate: display) matching_function;
 }
-
-(* ************************************************************************** *)
-
-let prefixes_first =
-  List.partition (function
-    | (_, [(true, _, _); (false, _, _)]) -> true
-    |  _                                 -> false)
-  %> uncurry (@)
-
-let reorder_matched_fun = ref identity
-let reorder_matched l = !reorder_matched_fun l
-let set_reorder_matched_fun f = reorder_matched_fun := f

--- a/lib/candidate.ml
+++ b/lib/candidate.ml
@@ -12,7 +12,7 @@ let make ?real ?(doc = "") ?matching_function ?completion display : t = {
   display; doc;
   real = Option.default display real;
   completion = Option.default display completion;
-  matching_function = 
+  matching_function =
     Option.default (Matching.match_query ~candidate: display) matching_function;
 }
 

--- a/lib/candidate.mli
+++ b/lib/candidate.mli
@@ -14,7 +14,7 @@ type t = {
   (** How to know if the user's input matches this candidate *)
 }
 (** The type of candidates.
-    
+
     A candidate is a possibility for completion or matching returned
     by sources. In dmenu, candidates were only strings but now we add
     more structure to differentiate the information and the way it

--- a/lib/candidate.mli
+++ b/lib/candidate.mli
@@ -29,19 +29,3 @@ val make : ?real:string -> ?doc:string -> ?matching_function:Matching.t ->
     - doc: [""]
     - matching_function: [Matching.match_query ~candidate]
 *)
-
-(** {3 Reordering functions} *)
-
-(** After matching on candidates, a reordering function is called that can
-    change their order. *)
-
-val reorder_matched : (t * Matching.result) list -> (t * Matching.result) list
-(** The reordering function (by default, the identity). *)
-
-val set_reorder_matched_fun : ((t * Matching.result) list -> (t * Matching.result) list) -> unit
-(** Set the reordering function. *)
-
-(** {2 Predefined reordering functions} *)
-
-(** Reorder the candidates to put prefix matchings first. *)
-val prefixes_first : (t * Matching.result) list -> (t * Matching.result) list

--- a/lib/candidate.mli
+++ b/lib/candidate.mli
@@ -4,7 +4,7 @@ type t = {
   display: string;
   (** How to display the candidate to the user. *)
   real: string;
-  (** What information it represent *)
+  (** What information it represents *)
   doc : string;
   (** Additional information that may be displayed to the user. *)
   completion: string;
@@ -18,16 +18,16 @@ type t = {
     A candidate is a possibility for completion or matching returned
     by sources. In dmenu, candidates were only strings but now we add
     more structure to differentiate the information and the way it
-    should be matched, displayed to the user. *)
+    should be matched or displayed to the user. *)
 
-    
+
 val make : ?real:string -> ?doc:string -> ?matching_function:Matching.t ->
   ?completion:string -> string -> t
 (** [make ~real ~doc ~matching_function ~completion display]
     creates a new candidate. The default values are:
-    - real, completion: display
-    - doc: empty
-    - matching_function: Matching.match_query ~candidate
+    - real, completion: [display]
+    - doc: [""]
+    - matching_function: [Matching.match_query ~candidate]
 *)
 
 (** {3 Reordering functions} *)

--- a/lib/matching.mli
+++ b/lib/matching.mli
@@ -5,12 +5,14 @@
     {!set_match_query_fun} (in hooks for instance).
 *)
 type result = ((bool * int * int) list)
-(** The return type of matching functions.  If it succeeded Some l, a list of
-    terms (match, start, stop) that denotes substring of the candidates that are
-    matched or not.
+(** The return type of matching functions.  If a matching function succeeded
+    returning [Some l], then [l] must be a list of terms [(match, start, stop)],
+    splitting the candidate into substrings, where [match] describes whether the
+    substring is matched or not.
 
-    This is used to display feedback to the user on the matching bits
-    of the candidate. *)
+    For example: if substring ["bar"] of candidate ["foobarbaz"] is matched, the
+    corresponding {!result} is [[(false, 0, 3); (true, 3, 6); (false, 6, 9)]].
+*)
 
 type t = string -> result option
 (** The type of matching functions *)

--- a/lib/matching.mli
+++ b/lib/matching.mli
@@ -1,6 +1,6 @@
 (** Functions used to match candidates. *)
 
-(** Default sources (defined in {!Sources} use the default
+(** Default sources (defined in {!Sources}) use the default
     {!match_query} match function that you can change using
     {!set_match_query_fun} (in hooks for instance).
 *)
@@ -8,7 +8,8 @@ type result = ((bool * int * int) list)
 (** The return type of matching functions.  If a matching function succeeded
     returning [Some l], then [l] must be a list of terms [(match, start, stop)],
     splitting the candidate into substrings, where [match] describes whether the
-    substring is matched or not.
+    substring is matched or not. There must be at least one substring with
+    [match] being [true].
 
     For example: if substring ["bar"] of candidate ["foobarbaz"] is matched, the
     corresponding {!result} is [[(false, 0, 3); (true, 3, 6); (false, 6, 9)]].
@@ -56,5 +57,5 @@ val trivial : candidate: string -> t
     some two-dimensional magic. *)
 
 val on : (string -> string) -> t -> t
-(** [on t matching_function] returns a new matching function that as
-    [matching_function] on the output of [t] *)
+(** [on f matching_function] returns a new matching function that applies
+    [matching_function] on the output of [f] *)

--- a/lib/ordering.ml
+++ b/lib/ordering.ml
@@ -1,0 +1,14 @@
+open Batteries
+
+type matched_candidate = Candidate.t * Matching.result
+type t = matched_candidate list -> matched_candidate list
+
+let prefixes_first =
+  List.partition (function
+    | (_, [(true, _, _); (false, _, _)]) -> true
+    |  _                                 -> false)
+  %> uncurry (@)
+
+let reorder_matched_fun = ref identity
+let reorder_matched l = !reorder_matched_fun l
+let set_reorder_matched_fun f = reorder_matched_fun := f

--- a/lib/ordering.ml
+++ b/lib/ordering.ml
@@ -3,11 +3,19 @@ open Batteries
 type matched_candidate = Candidate.t * Matching.result
 type t = matched_candidate list -> matched_candidate list
 
-let prefixes_first =
-  List.partition (function
-    | (_, [(true, _, _); (false, _, _)]) -> true
-    |  _                                 -> false)
-  %> uncurry (@)
+let prefixes_first l =
+  let prefixes, other =
+    List.partition (function
+      | (_, [(true, _, _); (false, _, _)]) -> true
+      | (_, [(true, _, _)])                -> true
+      |  _                                 -> false) l
+  in
+  let full_matchs, strict_prefixes =
+    List.partition (function
+      | (_, [(true, _, _)]) -> true
+      | _                   -> false) prefixes
+  in
+  full_matchs @ strict_prefixes @ other
 
 let reorder_matched_fun = ref identity
 let reorder_matched l = !reorder_matched_fun l

--- a/lib/ordering.mli
+++ b/lib/ordering.mli
@@ -20,5 +20,6 @@ val set_reorder_matched_fun : t -> unit
 
 (** {2 Predefined reordering functions} *)
 
-(** Reorder the candidates to put prefix matchings first. *)
+(** Reorder the candidates to put prefix matchings first (and among prefixes,
+    full matches first) *)
 val prefixes_first : t

--- a/lib/ordering.mli
+++ b/lib/ordering.mli
@@ -1,0 +1,24 @@
+(** Functions used to (re)order the list of candidates after matching. *)
+
+(** State transition functions (defined in {!State}, used by {!Dmlenu.run}) use
+    the default {!reorder_matched} reordering function, that you can change
+    using {!set_reorder_matched_fun}. *)
+
+type matched_candidate = Candidate.t * Matching.result
+(** A candidate that has been successfully matched. *)
+
+type t = matched_candidate list -> matched_candidate list
+(** The type of ordering functions *)
+
+(** {3 Reordering function} *)
+
+val reorder_matched : t
+(** The default reordering function: by default, the identity *)
+
+val set_reorder_matched_fun : t -> unit
+(** Set the default reordering function *)
+
+(** {2 Predefined reordering functions} *)
+
+(** Reorder the candidates to put prefix matchings first. *)
+val prefixes_first : t

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -45,7 +45,7 @@ let update_sources ?(input="") split sources =
     r := !r @ List.filter_map test candidates; (* !r is empty most of the times *)
     Source.ST (state', s))
   in
-  sources, Pagination.from_list split (Candidate.reorder_matched !r)
+  sources, Pagination.from_list split (Ordering.reorder_matched !r)
 
 let update_layout state candidates =
   match state.layout with


### PR DESCRIPTION
This PR mainly moves the candidates reordering functions, introduced in 48f1dce24c3, to a separate `Ordering` module.

Also:
- documentation fixes/improvements
- Fix a bug with `Ordering.prefixes_first`; full matches were not considered prefixes. We now additionally ensure that they come first
- Fix the `_oasis` by removing trailing spaces; it apparently makes `oasis setup` fail now.