### PR TITLE
Cleanups & fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all:
-	jbuilder build @install
+	dune build @install
 
 clean:
 	@rm -r _build
 
 examples:
-	jbuilder build examples/main.exe examples/i3_workspaces.exe examples/with_subcommands.exe
+	dune build @examples
 
 .PHONY: all examples clean

--- a/examples/dune
+++ b/examples/dune
@@ -1,0 +1,23 @@
+(executable
+ (name main)
+ (modules main)
+ (libraries dmlenu dmlenu_extra cmdliner))
+
+(executable
+ (name i3_workspaces)
+ (modules i3_workspaces)
+ (libraries dmlenu dmlenu_extra))
+
+(executable
+ (name mpc2D)
+ (modules mpc2D)
+ (libraries dmlenu dmlenu_extra))
+
+(executable
+ (name with_subcommands)
+ (modules with_subcommands)
+ (libraries dmlenu dmlenu_extra))
+
+(alias
+ (name examples)
+ (deps main.exe i3_workspaces.exe mpc2D.exe with_subcommands.exe))

--- a/examples/i3_workspaces.ml
+++ b/examples/i3_workspaces.ml
@@ -20,5 +20,5 @@ let () =
     | _ ->
       let ws = get_workspace "Go to:" in
       Unix.execvp "i3-msg" [| "i3-msg" ; "-q" ; "workspace" ; ws |]
-  with e ->
+  with _ ->
     exit 1

--- a/examples/mpc2D.ml
+++ b/examples/mpc2D.ml
@@ -1,9 +1,11 @@
+open Dmlenu
+
 let (!!) x = Lazy.from_val (Engine.singleton x)
 
 let engine = Engine.csum [
-  "play", !! Extra_sources.Mpc.current_playlist ;
-  "load", !! Extra_sources.Mpc.playlists ;
+  "play", !! Dmlenu_extra.Sources.Mpc.current_playlist ;
+  "load", !! Dmlenu_extra.Sources.Mpc.playlists ;
   "random", !! (Source.from_list_ ["on" ; "off"]) ;
 ]
 
-let _ = Dmlenu.run ~prompt:"mpc" ~layout:(State.Grid (10, None)) engine
+let _ = App.run ~prompt:"mpc" ~layout:(State.Grid (10, None)) engine

--- a/examples/with_subcommands.ml
+++ b/examples/with_subcommands.ml
@@ -38,4 +38,4 @@ let run =
   in
   match run_list ~hook stm with
   | [] -> ()
-  | prog :: params as lst -> Unix.execv prog (Array.of_list lst)
+  | prog :: _ as lst -> Unix.execv prog (Array.of_list lst)

--- a/lib/app.ml
+++ b/lib/app.ml
@@ -24,7 +24,7 @@ let splith state list =
 
 let incr ~xstate = X.Draw.update_x ~state: xstate ((+) 5)
 
-let draw_horizontal { xstate; state } =
+let draw_horizontal { xstate; state; _ } =
   let open State in
   let candidates = state.candidates in
   if not (List.is_empty candidates.Pagination.unvisible_left) then (
@@ -45,7 +45,7 @@ let rec shorten ~state candidate s =
     s
   else
     shorten ~state candidate
-      (try "..." ^ String.sub s 10 (String.length s - 10) with _ -> "")
+      (try "..." ^ String.sub s ~pos:10 ~len:(String.length s - 10) with _ -> "")
 
 let draw_vertical xstate topbar candidates =
   let init, f =
@@ -76,12 +76,12 @@ let resize =
       X.resize ~state ~lines
     )
 
-let draw ({ xstate; prompt; state } as app_state) =
+let draw ({ xstate; prompt; state; _ } as app_state) =
   let open State in
   let lines =
     match state.layout with
     | SingleLine | Grid (_, None) -> 0
-    | Grid (n, Some { pages }) -> min n (List.length pages.Pagination.visible)
+    | Grid (n, Some { pages; _ }) -> min n (List.length pages.Pagination.visible)
     | MultiLine n ->
       min n (List.length state.State.candidates.Pagination.visible)
   in
@@ -144,7 +144,7 @@ let run_list ?(topbar = true) ?(separator = " ") ?(colors = X.Colors.default)
       let open X.Events in
       draw state;
       match X.Events.poll ~state: xstate ~timeout: 1. with
-      | Some (Key X.Key.Escape) -> X.quit xstate; []
+      | Some (Key X.Key.Escape) -> X.quit ~state:xstate; []
 
       | Some (Key X.Key.Left)  -> loop_pure State.left
       | Some (Key X.Key.Up)    -> loop_pure State.up
@@ -154,7 +154,7 @@ let run_list ?(topbar = true) ?(separator = " ") ?(colors = X.Colors.default)
       | Some (Key X.Key.Scroll_up)   -> loop_pure State.scroll_up
       | Some (Key X.Key.Scroll_down) -> loop_pure State.scroll_down
 
-      | Some (Key X.Key.Enter) -> X.quit xstate; State.get_list state.state
+      | Some (Key X.Key.Enter) -> X.quit ~state:xstate; State.get_list state.state
 
       | Some (Key X.Key.Tab) -> loop_transition State.complete
 

--- a/lib/app.mli
+++ b/lib/app.mli
@@ -9,6 +9,7 @@ type app_state = {
   xstate: X.state; (** Data related to X *)
 }
 (** The current state of the application *)
+
 val run_list : 
   ?topbar: bool
   -> ?separator: string

--- a/lib/matching.ml
+++ b/lib/matching.ml
@@ -22,16 +22,18 @@ let make_list candidate list =
 
 let subset ?(case=true) ~candidate query =
   let query, candidate = handle_case case query candidate in
+  let opt_value_exn = function Some x -> x | None -> raise Caml.Not_found in
   try
-    let words = List.filter ~f:String.is_empty (String.split query ~on:' ') in
+    let words =
+      List.filter ~f:(Fn.non String.is_empty) (String.split query ~on:' ') in
     let matches = List.map ~f:(fun word ->
-      let n = String.substr_index_exn candidate ~pattern:word in
+      let n = String.substr_index candidate ~pattern:word |> opt_value_exn in
       (n, n + String.length word)) words
     in
     Some
       (make_list candidate
          (List.sort ~compare:(fun x y -> compare (fst x) (fst y)) matches))
-  with Caml.Not_found | Not_found_s _ -> None
+  with Caml.Not_found -> None
 
 let partial_match ?(case=true) ~candidate query =
   let query, candidate = handle_case case query candidate in

--- a/lib/pagination.ml
+++ b/lib/pagination.ml
@@ -29,7 +29,7 @@ let page_left p =
   let visible, unvisible = p.split p.unvisible_left in
   match visible with
   | [] -> p
-  | t :: q ->
+  | _ :: _ ->
     { p with
       unvisible_left = unvisible;
       unvisible_right = p.visible @ p.unvisible_right;
@@ -39,7 +39,7 @@ let page_right p =
   let visible, unvisible = p.split p.unvisible_right in
   match visible with
   | [] -> p
-  | t :: q ->
+  | _ :: _ ->
     { p with
       unvisible_right = unvisible;
       unvisible_left = List.rev p.visible @ p.unvisible_left;

--- a/lib/source.ml
+++ b/lib/source.ml
@@ -21,8 +21,8 @@ let rec compute_word_index ?(acc = 0) words position = match words with
   | [] -> acc, 0, "", ""
   | t :: q ->
     if position <= String.length t then (
-      acc, position, String.sub t 0 position,
-      String.sub t position (String.length t - position)
+      acc, position, String.sub t ~pos:0 ~len:position,
+      String.sub t ~pos:position ~len:(String.length t - position)
     ) else
       compute_word_index ~acc:(acc + 1) q (position - String.length t - 1)
 
@@ -70,6 +70,9 @@ let complete_in_word ?(drop_cont = false) separator f before after =
   let before, after = w.new_word (f w.before_inside w.after_inside) in
   before, if drop_cont then "" else after
 
+(* ? *)
+let _ = complete_in_word
+
 let match_in_word separator f query =
   let { word ; _ } = get_word separator query "" in
   f word
@@ -91,7 +94,7 @@ let expand_tilde s = try
   with _ -> s
 
 (* Actual sources *)
-let files ?(filter=fun x -> true) root =
+let files ?(filter=fun _ -> true) root =
   let root = root / "" in (* make it end by a slash *)
   let compute (old_dir, cache) query =
     let query = expand_tilde query in
@@ -198,7 +201,7 @@ let switch list =
     default_state = None;
     compute = fun st query ->
       let (S source) =
-        Lazy.force (snd (List.find_exn ~f:(fun (f, b) -> f query) list))
+        Lazy.force (snd (List.find_exn ~f:(fun (f, _b) -> f query) list))
       in
       match st with
       | Some (ST (state, source'))

--- a/lib/source.mli
+++ b/lib/source.mli
@@ -77,14 +77,19 @@ val stdin : ?sep:char -> unit -> t
     then lines are split wrt it and the first part is used as the
     display and the second part as the real. *)
 
+
 val update_candidates : (Candidate.t -> Candidate.t) -> t -> t
 (** Update the candidates returned by this source *)
+
 val update_matching : (Matching.t -> Matching.t) -> t -> t
 (** Update the matching function of the candidates returned by this source *)
+
 val update_completion : (string -> string) -> t -> t
 (** Update the completion of the candidates returned by this source *)
+
 val update_display : (string -> string) -> t -> t
 (** Update the display of the candidates returned by this source *)
+
 val update_real : (string -> string) -> t -> t
 (** Update the real of the candidates returned by this source *)
 

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -60,7 +60,6 @@ val left : t -> t
 
 val right : t -> t
 (** Moves the current selection to the right *)
-(** Moves right *)
 
 val up : t -> t
 (** Moves the current selection to the up *)

--- a/lib/x.ml
+++ b/lib/x.ml
@@ -40,7 +40,7 @@ type state = {
 
 let colors s = s.colors
 
-let quit ~state = Low_level.quit ()
+let quit ~state:_ = Low_level.quit ()
 let setup ~topbar ~colors ~lines = 
   Low_level.setup topbar colors.Colors.window_background lines;
   if Low_level.grabkeys () then
@@ -48,11 +48,11 @@ let setup ~topbar ~colors ~lines =
   else
     None
 
-let resize ~state ~lines = 
+let resize ~state:_ ~lines =
   Low_level.resize lines
 
-let width ~state = Low_level.width ()
-let text_width ~state s = Low_level.size s
+let width ~state:_ = Low_level.width ()
+let text_width ~state:_ s = Low_level.size s
 
 module Draw = struct
     let set_line ~state ~line =
@@ -82,7 +82,7 @@ module Draw = struct
       state.x <- 0;
       state.line <- 0;
       Low_level.clear state.colors.Colors.window_background
-    let map ~state = Low_level.mapdc ()
+    let map ~state:_ = Low_level.mapdc ()
 end
 
 module Key = struct
@@ -118,6 +118,6 @@ module Events = struct
   type t = 
     | Key of Key.t
 
-  let poll ~state ~timeout = 
+  let poll ~state:_ ~timeout:_ =
     Some (Key (Key.of_int (Low_level.next_event ())))
 end

--- a/lib/x.mli
+++ b/lib/x.mli
@@ -67,10 +67,13 @@ module Draw : sig
     
     val set_line : state: state -> line: int -> unit
     (** Set the current line of drawing *)
+
     val set_x : state: state -> x: int -> unit
     (** sets the current X position to draw *)
+
     val update_x : state: state -> (int -> int) -> unit
     (** Updates the current X position *)
+
     val text: state: state -> focus: bool -> ('a, unit, string, unit) format4 -> 'a
     (** Draw some text at the current position. [focus] is used to
         know which colors to use *)
@@ -87,6 +90,7 @@ module Draw : sig
     val map : state: state -> unit
     (** Map the window on the screen *)
 end
+
 (** Low-level interface *)
 module Low_level : sig
   external setup : bool -> string -> int -> unit = "caml_setup"


### PR DESCRIPTION
- fix dune-related warnings
- add a dune file for the examples
- fix Matching.subset: the current implementation is buggy and never matches. this was due to the combination of two bugs: the use of String.is_empty instead of its negation, and then the fact that String.substr_index_exn (from Base) seems to be raising an uncatchable exception.
My fix is probably not idiomatic, but I'm not familiar enough with base to think of a better way.
Suggestions welcome.

Note: the documentation of `subset` does not seem to match the current implementation; but I don't know whether one should fix the doc or the implementation.