### PR TITLE
Fix Matching.subset (again)

### DIFF
--- a/lib/matching.mli
+++ b/lib/matching.mli
@@ -31,8 +31,8 @@ val set_match_query_fun : (candidate:string -> t) -> unit
 (** NB: for the following functions the default value of [case] is [true] (case sensitive search). *)
 
 val subset : ?case:bool -> candidate:string -> t
-(** [subset ?case ~candidate query] will match if query (interpreded as a set of
-    characters) is a subset of candidate (interpreted as a set of chars again).
+(** [subset ?case ~candidate query] will match if the words of the query
+    can be found in the candidate (in any order, and possibly overlapping).
 *)
 
 val partial_match : ?case:bool -> candidate:string -> t


### PR DESCRIPTION
- the matching result returned by Matching.subset would sometime contain overlapping regions, which could possibly confuse the drawing code
- I tried reimplementing Matching.subset in a way that matches the current docstring, but the user experience is terrible (in my experience, just matching a subset as sets of characters matches too many random things). So instead, I updated the docstring to match the behavior of the current implementation (which I find provides much better UX).