### PR TITLE
Fix `examples/with_subcommand`

### DIFF
--- a/examples/with_subcommands.ml
+++ b/examples/with_subcommands.ml
@@ -4,7 +4,7 @@ open Candidate
 let stm =
   let open Engine in
   {
-    sources = [ Source.binaries ] ;
+    sources = [ Lazy.force Source.binaries ] ;
     transition =
       fun cmd ->
         if cmd.display = "chromium" then

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -206,11 +206,7 @@ let get_list state =
     else
       (fst (Pagination.selected state.candidates)).real
   in
-  let l =
-    if String.is_empty (state.before_cursor ^ state.after_cursor)
-    then []
-    else [ s ]
-  in
+  let l = if String.is_empty s then [] else [ s ] in
   List.map ~f:(fun (_, s) -> s.real) state.entries @ l
 
 let normalize state =


### PR DESCRIPTION
Lazy binaries introduced in d0681973028b0fef47d3f5820412dfb0ec343882 breaks that example.

(tested with OCaml 4.08.0)